### PR TITLE
trading: wrong balance fields for Cryptopia (#323)

### DIFF
--- a/web/yaamp/core/trading/cryptopia_trading.php
+++ b/web/yaamp/core/trading/cryptopia_trading.php
@@ -88,7 +88,8 @@ function doCryptopiaTrading($quick=false)
 
 		$market = getdbosql('db_markets', "coinid=:coinid AND name='cryptopia'", array(':coinid'=>$coin->id));
 		if(!$market) continue;
-		$market->balance = $balance->HeldForTrades;
+		$market->balance = $balance->Available;
+		$market->ontrade = $balance->HeldForTrades;
 		$market->message = $balance->StatusMessage;
 
 		$orders = NULL;


### PR DESCRIPTION
Fixing a typo in balance update:
$market->balance was updated by $balance->HeldForTrades but should be $balance-.Available
This caused properly updated balance in previous loop to be overwritten by wrong value.