### PR TITLE
wallet: show worker names if no password/extra

### DIFF
--- a/web/yaamp/modules/site/results/wallet_miners_results.php
+++ b/web/yaamp/modules/site/results/wallet_miners_results.php
@@ -104,6 +104,8 @@ if(count($workers))
 
 		$version = substr($worker->version, 0, 20);
 		$password = substr($worker->password, 0, 32);
+		if (empty($password) && !empty($worker->worker))
+			$password = substr($worker->worker, 0, 32);
 
 		$subscribe = Booltoa($worker->subscribe);
 


### PR DESCRIPTION
can be useful for miners without password argument (like gominer)