### PR TITLE
API difficulty fix to remove Itoa2 for cross compatibility

### DIFF
--- a/web/yaamp/modules/api/ApiController.php
+++ b/web/yaamp/modules/api/ApiController.php
@@ -162,17 +162,21 @@ class ApiController extends CommonController
 				$btcmhd = yaamp_profitability($coin);
 				$btcmhd = mbitcoinvaluetoa($btcmhd);
 				
-				$difficulty = Itoa2($coin->difficulty, 3);
+				//Add network hash difficulty and symbol
+                		$min_ttf = $coin->network_ttf>0? min($coin->actual_ttf, $coin->network_ttf): $coin->actual_ttf;
+                		$network_hash = $coin->difficulty * 0x100000000 / ($min_ttf? $min_ttf: 60);
 
 				$data[$symbol] = array(
 					'algo' => $coin->algo,
 					'port' => getAlgoPort($coin->algo),
 					'name' => $coin->name,
+					'reward' => $coin->reward,
 					'height' => (int) $coin->block_height,
 					'difficulty' => $difficulty,
 					'workers' => $workers,
 					'shares' =>  (int) arraySafeVal($shares,'shares'),
 					'hashrate' => round($factor * $algo_hashrate),
+					'network_hashrate' => $network_hash,
 					'estimate' => $btcmhd,
 					//'percent' => round($factor * 100, 1),
 					'24h_blocks' => (int) arraySafeVal($res24h,'a'),


### PR DESCRIPTION
This quick API update help to share  reward, difficulty and network_hashrate.   It include the removing of the Itoa2 to keep the real number of the difficulty for prevening bug on cointomine when the pool api is listed.
It also add the network hashrate to yiimp based on the current difficulty and Time To Find.
Note : The modification of ApiController.php not need reboot.