### PR TITLE
correct slow-memory leak in monitor

### DIFF
--- a/stratum/stratum.cpp
+++ b/stratum/stratum.cpp
@@ -386,30 +386,30 @@ int main(int argc, char **argv)
 
 void *monitor_thread(void *p)
 {
-	int cacheHeight = 0;
-
 	while(!g_exiting)
 	{
-		sleep(0.2);
+		sleep(120);
 
-		g_list_coind.Enter();
-		for(CLI li = g_list_coind.first; li; li = li->next)
+		if(g_last_broadcasted + YAAMP_MAXJOBDELAY < time(NULL))
 		{
-			YAAMP_COIND *coind = (YAAMP_COIND *)li->data;
-			json_value *json = rpc_call(&coind->rpc, "getblockcount");
-			if (!json) continue;
-			json_int_t amount = json_get_int(json, "result");
+			g_exiting = true;
+			stratumlogdate("%s dead lock, exiting...\n", g_stratum_algo);
+			exit(1);
+		}
 
-			if (coind->height != amount) {
-                                if (coind->height != cacheHeight) {
-				      debuglog("coind->height differs from rpc response, forcing new template (%d vs %d)..\n", coind->height, amount);
-                                      cacheHeight = coind->height;
-                                }
-				coind_create_job(coind, true);
-				job_update();
+		if(g_max_shares && g_shares_counter) {
+
+			if((g_shares_counter - g_shares_log) > 10000) {
+				stratumlogdate("%s %luK shares...\n", g_stratum_algo, (g_shares_counter/1000u));
+				g_shares_log = g_shares_counter;
+			}
+
+			if(g_shares_counter > g_max_shares) {
+				g_exiting = true;
+				stratumlogdate("%s need a restart (%lu shares), exiting...\n", g_stratum_algo, (unsigned long) g_max_shares);
+				exit(1);
 			}
 		}
-		g_list_coind.Leave();
 	}
 }
 


### PR DESCRIPTION
this commit was only meant for sugarchain;
in order to keep up with its 5s block times,
wasn't meant to be applied codebase wide..